### PR TITLE
Make OAuth Redirect URI Configurable

### DIFF
--- a/dcr_test.go
+++ b/dcr_test.go
@@ -93,3 +93,86 @@ func TestPerformDCR_NoRegistrationEndpoint(t *testing.T) {
 		t.Error("Expected nil credentials on error")
 	}
 }
+
+// TestIsValidRedirectURI verifies redirect URI validation logic
+func TestIsValidRedirectURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		redirectURI string
+		expectError bool
+		description string
+	}{
+		{
+			name:        "empty string",
+			redirectURI: "",
+			expectError: false,
+			description: "Empty string should be allowed (uses default)",
+		},
+		{
+			name:        "localhost http",
+			redirectURI: "http://localhost:5000/callback",
+			expectError: false,
+			description: "Localhost with HTTP should be allowed",
+		},
+		{
+			name:        "localhost https",
+			redirectURI: "https://localhost:5000/callback",
+			expectError: false,
+			description: "Localhost with HTTPS should be allowed",
+		},
+		{
+			name:        "127.0.0.1",
+			redirectURI: "http://127.0.0.1:8080/callback",
+			expectError: false,
+			description: "127.0.0.1 should be allowed",
+		},
+		{
+			name:        "IPv6 localhost",
+			redirectURI: "http://[::1]:8080/callback",
+			expectError: false,
+			description: "IPv6 localhost should be allowed",
+		},
+		{
+			name:        "mcp.docker.com production",
+			redirectURI: "https://mcp.docker.com/oauth/callback",
+			expectError: false,
+			description: "Production mcp.docker.com should be allowed",
+		},
+		{
+			name:        "evil domain",
+			redirectURI: "https://evil.com/callback",
+			expectError: true,
+			description: "Arbitrary domains should be blocked",
+		},
+		{
+			name:        "attacker ngrok",
+			redirectURI: "https://attacker.ngrok.io/callback",
+			expectError: true,
+			description: "Attacker-controlled domains should be blocked",
+		},
+		{
+			name:        "subdomain of docker.com",
+			redirectURI: "https://evil.docker.com/callback",
+			expectError: true,
+			description: "Only mcp.docker.com should be allowed, not subdomains",
+		},
+		{
+			name:        "invalid URL",
+			redirectURI: "not-a-valid-url",
+			expectError: true,
+			description: "Invalid URL format should be rejected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := isValidRedirectURI(tt.redirectURI)
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error for %q (%s)", tt.redirectURI, tt.description)
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error for %q: %v (%s)", tt.redirectURI, err, tt.description)
+			}
+		})
+	}
+}


### PR DESCRIPTION
 **What I did**

 Made the OAuth redirect URI configurable in the DCR (Dynamic Client Registration) helper library while maintaining backwards
  compatibility.

 **Changes:**
  - Added redirectURI parameter to PerformDCR() function
  - Implemented automatic fallback to default https://mcp.docker.com/oauth/callback when empty string is passed
  - Added DefaultRedirectURI constant for consumers to reference
  - Maintains backwards compatibility: old consumers can pass "" to use default behavior

  Why:
  - Enables CE (Community Edition) mode to use localhost redirect URIs for OAuth flows
  - Allows different deployment modes (Desktop vs CE) to use appropriate callback URLs
  - Supports flexible OAuth configurations without hardcoding redirect destinations

  API Change:
  // Before (hypothetical old signature):
  PerformDCR(ctx, discovery, serverName)

  // After (backwards compatible):
  PerformDCR(ctx, discovery, serverName, "")                           // Uses default
  PerformDCR(ctx, discovery, serverName, "http://localhost:5000/callback")  // Custom

  **Migration Guide for Consumers:**
  Existing code needs minimal update - just add "" as 4th parameter to use default redirect URI:
  - creds, err := oauth.PerformDCR(ctx, discovery, "github")
  + creds, err := oauth.PerformDCR(ctx, discovery, "github", "")

  **Related issue**
  Enables implementation of mcp-gateway CE mode OAuth flow with localhost callbacks.