### PR TITLE
Fix well-known URL construction when issuer contains a path according to spec: (RFC 8414)

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -12,6 +12,11 @@ import (
 	"time"
 )
 
+// httpClientFunc allows tests to inject a custom HTTP client (e.g., for TLS test servers)
+var httpClientFunc = func() *http.Client {
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
 // DiscoverOAuthRequirements probes an MCP server to discover OAuth requirements
 //
 // MCP AUTHORIZATION SPEC COMPLIANCE:
@@ -36,10 +41,8 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 
 	logger.Infof("starting OAuth discovery for server: %s", serverURL)
 
-	// Create HTTP client with reasonable timeout
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
+	// Create HTTP client (can be overridden in tests for TLS support)
+	client := httpClientFunc()
 
 	// Parse server URL to extract base domain for defaults
 	parsedURL, err := url.Parse(serverURL)
@@ -255,6 +258,24 @@ func buildRFC8414WellKnownURL(issuerURL string) (string, error) {
 		return "", fmt.Errorf("invalid issuer URL: %w", err)
 	}
 
+	// RFC 8414 Section 2: issuer must use https scheme
+	if parsed.Scheme != "https" {
+		return "", fmt.Errorf("issuer URL must use https scheme")
+	}
+
+	// RFC 8414 Section 2: issuer must not have query
+	if parsed.RawQuery != "" {
+		return "", fmt.Errorf("issuer URL must not contain query parameters")
+	}
+
+	// RFC 8414 Section 2: issuer must not have fragment
+	if parsed.Fragment != "" {
+		return "", fmt.Errorf("issuer URL must not contain fragment")
+	}
+
+	// RFC 3986 Section 3.2.2: host is case-insensitive, canonicalize to lowercase
+	host := strings.ToLower(parsed.Host)
+
 	// RFC 8414 Section 3.1: Insert .well-known between host and path
 	// Path may be empty, "/" or "/some/path"
 	path := parsed.Path
@@ -262,8 +283,8 @@ func buildRFC8414WellKnownURL(issuerURL string) (string, error) {
 		path = ""
 	}
 
-	return fmt.Sprintf("%s://%s/.well-known/oauth-authorization-server%s",
-		parsed.Scheme, parsed.Host, path), nil
+	return fmt.Sprintf("https://%s/.well-known/oauth-authorization-server%s",
+		host, path), nil
 }
 
 // fetchAuthorizationServerMetadata fetches metadata from /.well-known/oauth-authorization-server

--- a/discovery.go
+++ b/discovery.go
@@ -247,19 +247,37 @@ func fetchOAuthProtectedResourceMetadata(ctx context.Context, client *http.Clien
 	return &metadata, nil
 }
 
+// buildRFC8414WellKnownURL constructs the well-known URL per RFC 8414 Section 3.1
+// Inserts /.well-known/oauth-authorization-server between host and path.
+func buildRFC8414WellKnownURL(issuerURL string) (string, error) {
+	parsed, err := url.Parse(issuerURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid issuer URL: %w", err)
+	}
+
+	// RFC 8414 Section 3.1: Insert .well-known between host and path
+	// Path may be empty, "/" or "/some/path"
+	path := parsed.Path
+	if path == "/" {
+		path = ""
+	}
+
+	return fmt.Sprintf("%s://%s/.well-known/oauth-authorization-server%s",
+		parsed.Scheme, parsed.Host, path), nil
+}
+
 // fetchAuthorizationServerMetadata fetches metadata from /.well-known/oauth-authorization-server
 //
 // RFC 8414 COMPLIANCE:
 // - Implements RFC 8414 Section 3 "Authorization Server Metadata"
+// - Implements RFC 8414 Section 3.1 for well-known URL construction with path support
 // - Validates required fields: issuer, authorization_endpoint, token_endpoint
 // - Validates issuer URL matches authorization server URL (RFC 8414 Section 3.2)
 func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, authServerURL string) (*AuthorizationServerMetadata, error) {
-	// RFC 8414 Section 3: Construct well-known URL
-	var metadataURL string
-	if strings.HasSuffix(authServerURL, "/") {
-		metadataURL = authServerURL + ".well-known/oauth-authorization-server"
-	} else {
-		metadataURL = authServerURL + "/.well-known/oauth-authorization-server"
+	// RFC 8414 Section 3.1: Construct well-known URL (handles issuer paths correctly)
+	metadataURL, err := buildRFC8414WellKnownURL(authServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("building well-known URL: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -187,3 +187,47 @@ func TestDiscoveryError_AuthServerFails(t *testing.T) {
 		t.Errorf("Expected auth server error, got: %v", err)
 	}
 }
+
+// TestBuildRFC8414WellKnownURL verifies RFC 8414 Section 3.1 URL construction
+func TestBuildRFC8414WellKnownURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		issuer   string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "simple issuer without path",
+			issuer:   "https://example.com",
+			expected: "https://example.com/.well-known/oauth-authorization-server",
+		},
+		{
+			name:     "issuer with path",
+			issuer:   "https://access.stripe.com/mcp",
+			expected: "https://access.stripe.com/.well-known/oauth-authorization-server/mcp",
+		},
+		{
+			name:    "invalid URL",
+			issuer:  "://invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := buildRFC8414WellKnownURL(tt.issuer)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for issuer %q, got nil", tt.issuer)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for issuer %q: %v", tt.issuer, err)
+			}
+			if result != tt.expected {
+				t.Errorf("buildRFC8414WellKnownURL(%q)\n  got:  %s\n  want: %s", tt.issuer, result, tt.expected)
+			}
+		})
+	}
+}

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,6 +10,21 @@ import (
 	"strings"
 	"testing"
 )
+
+// setupTestHTTPClient configures httpClientFunc to accept test TLS certificates
+func setupTestHTTPClient(_ *testing.T) func() {
+	original := httpClientFunc
+	httpClientFunc = func() *http.Client {
+		return &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+	}
+	return func() {
+		httpClientFunc = original
+	}
+}
 
 // TestDiscoveryFallback_NoWWWAuthenticate verifies the critical fallback behavior
 // when MCP server doesn't provide WWW-Authenticate header
@@ -18,11 +34,14 @@ import (
 // - Don't provide WWW-Authenticate header (MCP spec violation)
 // - Do provide /.well-known/oauth-protected-resource endpoint (RFC 9728 compliant)
 func TestDiscoveryFallback_NoWWWAuthenticate(t *testing.T) {
-	// Mock authorization server
-	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	cleanup := setupTestHTTPClient(t)
+	defer cleanup()
+
+	// Mock authorization server (TLS)
+	authServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/.well-known/oauth-authorization-server") {
-			// Use r.Host to construct URLs dynamically
-			baseURL := "http://" + r.Host
+			// Use https scheme for test server
+			baseURL := "https://" + r.Host
 			_ = json.NewEncoder(w).Encode(AuthorizationServerMetadata{
 				Issuer:                        baseURL,
 				AuthorizationEndpoint:         baseURL + "/authorize",
@@ -35,8 +54,8 @@ func TestDiscoveryFallback_NoWWWAuthenticate(t *testing.T) {
 	}))
 	defer authServer.Close()
 
-	// Mock MCP server (returns 401 WITHOUT WWW-Authenticate)
-	mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Mock MCP server (returns 401 WITHOUT WWW-Authenticate) - TLS
+	mcpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/mcp" {
 			// Return 401 WITHOUT WWW-Authenticate header (Neon behavior)
 			w.WriteHeader(http.StatusUnauthorized)
@@ -44,10 +63,10 @@ func TestDiscoveryFallback_NoWWWAuthenticate(t *testing.T) {
 		}
 		if r.URL.Path == "/.well-known/oauth-protected-resource" {
 			// Provide resource metadata at well-known endpoint
-			baseURL := "http://" + r.Host
+			baseURL := "https://" + r.Host
 			_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
 				Resource:            baseURL,
-				AuthorizationServer: authServer.URL,
+				AuthorizationServer: authServer.URL, // httptest.NewTLSServer URL is already https
 			})
 			return
 		}
@@ -88,10 +107,13 @@ func TestDiscoveryFallback_NoWWWAuthenticate(t *testing.T) {
 // TestDiscoveryHappyPath_WithWWWAuthenticate verifies the standard flow
 // when server provides proper WWW-Authenticate header
 func TestDiscoveryHappyPath_WithWWWAuthenticate(t *testing.T) {
-	// Mock authorization server
-	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	cleanup := setupTestHTTPClient(t)
+	defer cleanup()
+
+	// Mock authorization server (TLS)
+	authServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/.well-known/oauth-authorization-server") {
-			baseURL := "http://" + r.Host
+			baseURL := "https://" + r.Host
 			_ = json.NewEncoder(w).Encode(AuthorizationServerMetadata{
 				Issuer:                        baseURL,
 				AuthorizationEndpoint:         baseURL + "/authorize",
@@ -103,8 +125,8 @@ func TestDiscoveryHappyPath_WithWWWAuthenticate(t *testing.T) {
 	}))
 	defer authServer.Close()
 
-	// Mock metadata server (separate from MCP server)
-	metadataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	// Mock metadata server (separate from MCP server) - TLS
+	metadataServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
 			Resource:            "https://api.example.com",
 			AuthorizationServer: authServer.URL,
@@ -113,8 +135,8 @@ func TestDiscoveryHappyPath_WithWWWAuthenticate(t *testing.T) {
 	}))
 	defer metadataServer.Close()
 
-	// Mock MCP server (returns 401 WITH WWW-Authenticate)
-	mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Mock MCP server (returns 401 WITH WWW-Authenticate) - TLS
+	mcpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/mcp" {
 			// Return 401 WITH WWW-Authenticate header (standard MCP behavior)
 			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer realm=\"test\", resource_metadata=\"%s\"", metadataServer.URL))
@@ -155,18 +177,21 @@ func TestDiscoveryHappyPath_WithWWWAuthenticate(t *testing.T) {
 // TestDiscoveryError_AuthServerFails verifies error handling
 // when authorization server metadata cannot be fetched
 func TestDiscoveryError_AuthServerFails(t *testing.T) {
-	// Mock MCP server (returns 401, no WWW-Authenticate)
-	mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	cleanup := setupTestHTTPClient(t)
+	defer cleanup()
+
+	// Mock MCP server (returns 401, no WWW-Authenticate) - TLS
+	mcpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/mcp" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 		if r.URL.Path == "/.well-known/oauth-protected-resource" {
 			// Return resource metadata pointing to non-existent auth server
-			baseURL := "http://" + r.Host
+			baseURL := "https://" + r.Host
 			_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
 				Resource:            baseURL,
-				AuthorizationServer: "http://localhost:99999", // Invalid/unreachable
+				AuthorizationServer: "https://localhost:99999", // Invalid/unreachable
 			})
 			return
 		}
@@ -195,6 +220,7 @@ func TestBuildRFC8414WellKnownURL(t *testing.T) {
 		issuer   string
 		expected string
 		wantErr  bool
+		errMsg   string
 	}{
 		{
 			name:     "simple issuer without path",
@@ -207,9 +233,33 @@ func TestBuildRFC8414WellKnownURL(t *testing.T) {
 			expected: "https://access.stripe.com/.well-known/oauth-authorization-server/mcp",
 		},
 		{
+			name:     "issuer with uppercase host (should lowercase)",
+			issuer:   "https://EXAMPLE.COM/path",
+			expected: "https://example.com/.well-known/oauth-authorization-server/path",
+		},
+		{
 			name:    "invalid URL",
 			issuer:  "://invalid",
 			wantErr: true,
+			errMsg:  "invalid issuer URL",
+		},
+		{
+			name:    "http scheme rejected (RFC 8414 requires https)",
+			issuer:  "http://example.com",
+			wantErr: true,
+			errMsg:  "must use https scheme",
+		},
+		{
+			name:    "query parameters rejected (RFC 8414 Section 2)",
+			issuer:  "https://example.com?foo=bar",
+			wantErr: true,
+			errMsg:  "must not contain query parameters",
+		},
+		{
+			name:    "fragment rejected (RFC 8414 Section 2)",
+			issuer:  "https://example.com#fragment",
+			wantErr: true,
+			errMsg:  "must not contain fragment",
 		},
 	}
 
@@ -219,6 +269,8 @@ func TestBuildRFC8414WellKnownURL(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected error for issuer %q, got nil", tt.issuer)
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got: %v", tt.errMsg, err)
 				}
 				return
 			}


### PR DESCRIPTION
**What I did**
Update well-known URL construction to account for paths (source:  https://datatracker.ietf.org/doc/html/rfc8414#section-3.1) 
- If: `https://example.com/issuer1` URL should be ->  `https://example.com/.well-known/oauth-authorization-server/issuer1`
- Previously we were simply appending: `.well-known/oauth-authorization-server` which is not spec compliant
- See issue: #4 

**Related issue**
- We are unable to discover Stripe's MCP server since we were discovering at: `https://access.stripe.com/mcp/.well-known/oauth-authorization-server` instead of: `https://access.stripe.com/.well-known/oauth-authorization-server/mcp`

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**