### PR TITLE
Add mcp-stage.docker.com as valid redirect URI host

### DIFF
--- a/dcr.go
+++ b/dcr.go
@@ -37,7 +37,12 @@ func isValidRedirectURI(redirectURI string) error {
 		return nil
 	}
 
-	return fmt.Errorf("redirect URI host %q not allowed - must be localhost or mcp.docker.com", hostname)
+	// Allow mcp-stage.docker.com (staging)
+	if hostname == "mcp-stage.docker.com" {
+		return nil
+	}
+
+	return fmt.Errorf("redirect URI host %q not allowed - must be localhost, mcp.docker.com, or mcp-stage.docker.com", hostname)
 }
 
 // PerformDCR performs Dynamic Client Registration with the authorization server

--- a/dcr_test.go
+++ b/dcr_test.go
@@ -139,6 +139,12 @@ func TestIsValidRedirectURI(t *testing.T) {
 			description: "Production mcp.docker.com should be allowed",
 		},
 		{
+			name:        "mcp-stage.docker.com staging",
+			redirectURI: "https://mcp-stage.docker.com/oauth/callback",
+			expectError: false,
+			description: "Staging mcp-stage.docker.com should be allowed",
+		},
+		{
 			name:        "evil domain",
 			redirectURI: "https://evil.com/callback",
 			expectError: true,
@@ -154,7 +160,7 @@ func TestIsValidRedirectURI(t *testing.T) {
 			name:        "subdomain of docker.com",
 			redirectURI: "https://evil.docker.com/callback",
 			expectError: true,
-			description: "Only mcp.docker.com should be allowed, not subdomains",
+			description: "Only mcp.docker.com and mcp-stage.docker.com should be allowed, not other subdomains",
 		},
 		{
 			name:        "invalid URL",


### PR DESCRIPTION
## Summary
- Add `mcp-stage.docker.com` as an allowed redirect URI host in `isValidRedirectURI()`
- Update error message to include the new allowed host
- Add test case for staging URL validation

## Test plan
- [x] Run `go test -v ./...` - all 22 tests pass
- [ ] Verify staging OAuth flow works with `https://mcp-stage.docker.com/oauth/callback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)