### PR TITLE
fix: treat no-auth remote servers as RequiresOAuth=false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Run tests
         run: make test
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Run linter for Linux
         run: make lint-linux

--- a/discovery.go
+++ b/discovery.go
@@ -72,9 +72,13 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 
 	logger.Infof("MCP server response: status=%d", resp.StatusCode)
 
-	// If not 401, OAuth might not be required (Authorization is OPTIONAL per MCP spec Section 2.1)
-	// We log a warning but continue discovery attempt in case server is misconfigured
-	if resp.StatusCode != http.StatusUnauthorized {
+	// If not 401, OAuth is likely not required (Authorization is OPTIONAL per
+	// MCP spec Section 2.1). We still attempt metadata discovery in case the
+	// server is misconfigured (needs OAuth but doesn't challenge with 401);
+	// however, if no authorization server metadata can then be discovered, we
+	// treat the server as requiring no OAuth rather than failing (see STEP 5).
+	oauthOptional := resp.StatusCode != http.StatusUnauthorized
+	if oauthOptional {
 		logger.Warnf("expected 401 Unauthorized, got %d - OAuth may not be required", resp.StatusCode)
 	}
 
@@ -143,6 +147,15 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 	authServerMetadata, err := fetchAuthorizationServerMetadata(ctx, client, authServerURL)
 	if err != nil {
 		logger.Warnf("failed to fetch authorization server metadata: %v", err)
+		// The server did not challenge with 401 and exposes no discoverable
+		// authorization server metadata: it requires no OAuth (auth is OPTIONAL
+		// per MCP spec Section 2.1), so report that rather than failing. Only a
+		// server that *did* return 401 but lacks usable metadata is a real
+		// (misconfigured-OAuth) error.
+		if oauthOptional {
+			logger.Infof("no authorization server metadata discovered and server did not require auth; treating as no-OAuth")
+			return &Discovery{RequiresOAuth: false}, nil
+		}
 		return nil, fmt.Errorf("fetching authorization server metadata from %s: %w", authServerURL, err)
 	}
 	logger.Infof("auth server metadata retrieved: token_endpoint=%s, registration_endpoint=%s",

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -104,6 +104,40 @@ func TestDiscoveryFallback_NoWWWAuthenticate(t *testing.T) {
 	}
 }
 
+// TestDiscovery_NoAuthServer verifies that a remote MCP server requiring NO
+// OAuth — it does not return 401 and exposes no authorization server metadata —
+// is reported as RequiresOAuth=false rather than failing discovery.
+// Authorization is OPTIONAL per MCP spec Section 2.1, so no-auth servers are
+// valid; previously such a server failed with a fatal "fetching authorization
+// server metadata" error.
+func TestDiscovery_NoAuthServer(t *testing.T) {
+	cleanup := setupTestHTTPClient(t)
+	defer cleanup()
+
+	// MCP server that needs no auth: 200 on the probe, 404 on the OAuth
+	// well-known endpoints (no authorization server metadata anywhere).
+	mcpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/mcp" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer mcpServer.Close()
+
+	logger := &testLogger{}
+	ctx := WithLogger(context.Background(), logger)
+
+	discovery, err := DiscoverOAuthRequirements(ctx, mcpServer.URL+"/mcp")
+	if err != nil {
+		t.Fatalf("Discovery should not fail for a no-auth server: %v", err)
+	}
+	if discovery.RequiresOAuth {
+		t.Error("Expected RequiresOAuth=false for a server that does not require OAuth")
+	}
+}
+
 // TestDiscoveryHappyPath_WithWWWAuthenticate verifies the standard flow
 // when server provides proper WWW-Authenticate header
 func TestDiscoveryHappyPath_WithWWWAuthenticate(t *testing.T) {


### PR DESCRIPTION
## Problem
`DiscoverOAuthRequirements` returns a hard error for a remote MCP server that requires **no** OAuth. Authorization is OPTIONAL per the MCP spec (§2.1), so a server that doesn't challenge with `401` and exposes no OAuth metadata is valid — but discovery currently fails with errors like `issuer URL must use https scheme` or `authorization server metadata endpoint returned status 404` instead of reporting "no OAuth required."

## Cause
The non-`401` branch intentionally continues discovery (to catch misconfigured servers that need OAuth but don't challenge with `401`), but it then always requires authorization server metadata; when none is discoverable it errors fatally — even for a server that simply has no OAuth.

## Fix
Track whether the server challenged with `401`. If it did **not**, and no authorization server metadata can be discovered, return `Discovery{RequiresOAuth: false}` instead of erroring. A server that **did** return `401` but lacks usable metadata is still treated as a (misconfigured) error, so the robustness behavior is preserved.

## Test
Adds `TestDiscovery_NoAuthServer`: a server returning `200` (no `401`) and `404` on the OAuth well-known endpoints is reported as `RequiresOAuth: false` with no error. Verified it fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
