### PR TITLE
Harden OAuth discovery metadata validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Run tests
         run: make test
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Run linter for Linux
         run: make lint-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@v3
 
       - name: Run tests
         run: make test
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@v3
 
       - name: Run linter for Linux
         run: make lint-linux

--- a/discovery.go
+++ b/discovery.go
@@ -107,6 +107,7 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 	var resourceMetadata *ProtectedResourceMetadata
 	var resourceMetadataError error
 	authServerURL := defaultAuthServerURL
+	resourceMetadataClient := sameOriginHTTPClient(client, serverURL)
 
 	// STEP 4: Try to get resource metadata (OPTIONAL - don't fail if missing)
 	// RFC 9728 Section 5.1: resource_metadata parameter in WWW-Authenticate
@@ -118,7 +119,16 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 	if resourceMetadataURL != "" {
 		// Resource metadata URL found - try to fetch it
 		logger.Infof("fetching protected resource metadata from: %s", resourceMetadataURL)
-		resourceMetadata, resourceMetadataError = fetchOAuthProtectedResourceMetadata(ctx, client, resourceMetadataURL)
+		if err := validateSameOrigin(serverURL, resourceMetadataURL); err != nil {
+			return nil, fmt.Errorf("invalid protected resource metadata URL: %w", err)
+		}
+		resourceMetadata, resourceMetadataError = fetchOAuthProtectedResourceMetadata(ctx, resourceMetadataClient, resourceMetadataURL)
+		if resourceMetadataError != nil {
+			return nil, fmt.Errorf("fetching protected resource metadata from %s: %w", resourceMetadataURL, resourceMetadataError)
+		}
+		if err := validateProtectedResource(serverURL, resourceMetadata.Resource); err != nil {
+			return nil, err
+		}
 		if resourceMetadataError == nil && resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
 			// Use authorization server from resource metadata if available
 			authServerURL = resourceMetadata.AuthorizationServer
@@ -128,9 +138,17 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 		}
 	} else {
 		// No resource_metadata in WWW-Authenticate - try well-known endpoint
-		wellKnownURL := fmt.Sprintf("%s/.well-known/oauth-protected-resource", defaultAuthServerURL)
+		wellKnownURL, err := buildRFC9728WellKnownURL(serverURL)
+		if err != nil {
+			return nil, fmt.Errorf("building protected resource metadata URL: %w", err)
+		}
 		logger.Infof("fallback: trying well-known resource metadata endpoint: %s", wellKnownURL)
-		resourceMetadata, resourceMetadataError = fetchOAuthProtectedResourceMetadata(ctx, client, wellKnownURL)
+		resourceMetadata, resourceMetadataError = fetchOAuthProtectedResourceMetadata(ctx, resourceMetadataClient, wellKnownURL)
+		if resourceMetadataError == nil && resourceMetadata != nil {
+			if err := validateProtectedResource(serverURL, resourceMetadata.Resource); err != nil {
+				return nil, err
+			}
+		}
 		if resourceMetadataError == nil && resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
 			authServerURL = resourceMetadata.AuthorizationServer
 			logger.Infof("resource metadata from well-known endpoint, auth server: %s", authServerURL)
@@ -153,8 +171,8 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 		RequiresOAuth: true,
 
 		// Use resource metadata if available, otherwise use defaults
-		ResourceURL:         defaultAuthServerURL,
-		ResourceServer:      defaultAuthServerURL,
+		ResourceURL:         serverURL,
+		ResourceServer:      serverURL,
 		AuthorizationServer: authServerURL,
 
 		// From Authorization Server Metadata (RFC 8414) - always available
@@ -333,6 +351,9 @@ func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, 
 	if metadata.Issuer == "" {
 		return nil, fmt.Errorf("issuer field missing in authorization server metadata")
 	}
+	if metadata.Issuer != authServerURL {
+		return nil, fmt.Errorf("authorization server metadata issuer %q does not match requested issuer %q", metadata.Issuer, authServerURL)
+	}
 	if metadata.AuthorizationEndpoint == "" {
 		return nil, fmt.Errorf("authorization_endpoint field missing in authorization server metadata")
 	}
@@ -341,13 +362,94 @@ func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, 
 	}
 
 	// RFC 8414 Section 3.2: Validate issuer URL is valid
-	// Note: We trust the issuer field in the metadata as authoritative
-	// Cross-domain OAuth setups (like Stripe) are valid where resource server
-	// and authorization server are on different domains
 	_, err = url.Parse(metadata.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("invalid issuer URL: %w", err)
 	}
 
 	return &metadata, nil
+}
+
+func validateProtectedResource(expected, actual string) error {
+	if actual != expected {
+		return fmt.Errorf("protected resource metadata resource %q does not match requested resource %q", actual, expected)
+	}
+	return nil
+}
+
+func validateSameOrigin(serverURL, metadataURL string) error {
+	server, err := url.Parse(serverURL)
+	if err != nil {
+		return fmt.Errorf("invalid server URL: %w", err)
+	}
+	metadata, err := url.Parse(metadataURL)
+	if err != nil {
+		return fmt.Errorf("invalid metadata URL: %w", err)
+	}
+	if server.Scheme == "" || server.Hostname() == "" || server.User != nil {
+		return fmt.Errorf("server URL must be an absolute URL without user information")
+	}
+	if metadata.Scheme == "" || metadata.Hostname() == "" || metadata.User != nil {
+		return fmt.Errorf("metadata URL must be an absolute URL without user information")
+	}
+
+	serverPort := server.Port()
+	if serverPort == "" {
+		serverPort = defaultPort(server.Scheme)
+	}
+	metadataPort := metadata.Port()
+	if metadataPort == "" {
+		metadataPort = defaultPort(metadata.Scheme)
+	}
+	if !strings.EqualFold(server.Scheme, metadata.Scheme) ||
+		!strings.EqualFold(server.Hostname(), metadata.Hostname()) ||
+		serverPort != metadataPort {
+		return fmt.Errorf("metadata URL %q must use the same origin as MCP server %q", metadataURL, serverURL)
+	}
+	return nil
+}
+
+func sameOriginHTTPClient(client *http.Client, originURL string) *http.Client {
+	cloned := *client
+	cloned.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+		return validateSameOrigin(originURL, req.URL.String())
+	}
+	return &cloned
+}
+
+func defaultPort(scheme string) string {
+	switch strings.ToLower(scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
+}
+
+// buildRFC9728WellKnownURL constructs the protected-resource metadata URL by
+// inserting the well-known suffix before the resource path while preserving
+// its query, as required by RFC 9728 Section 3.1.
+func buildRFC9728WellKnownURL(resourceURL string) (string, error) {
+	parsed, err := url.Parse(resourceURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid resource URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Hostname() == "" || parsed.User != nil {
+		return "", fmt.Errorf("resource URL must be an absolute URL without user information")
+	}
+	if parsed.Fragment != "" {
+		return "", fmt.Errorf("resource URL must not contain fragment")
+	}
+
+	resourcePath := parsed.EscapedPath()
+	if resourcePath == "/" {
+		resourcePath = ""
+	}
+	metadataURL := fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource%s", parsed.Scheme, strings.ToLower(parsed.Host), resourcePath)
+	if parsed.RawQuery != "" {
+		metadataURL += "?" + parsed.RawQuery
+	}
+	return metadataURL, nil
 }

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -61,11 +62,11 @@ func TestDiscoveryFallback_NoWWWAuthenticate(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		if r.URL.Path == "/.well-known/oauth-protected-resource" {
+		if r.URL.Path == "/.well-known/oauth-protected-resource/mcp" {
 			// Provide resource metadata at well-known endpoint
 			baseURL := "https://" + r.Host
 			_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
-				Resource:            baseURL,
+				Resource:            baseURL + "/mcp",
 				AuthorizationServer: authServer.URL, // httptest.NewTLSServer URL is already https
 			})
 			return
@@ -125,23 +126,21 @@ func TestDiscoveryHappyPath_WithWWWAuthenticate(t *testing.T) {
 	}))
 	defer authServer.Close()
 
-	// Mock metadata server (separate from MCP server) - TLS
-	metadataServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
-			Resource:            "https://api.example.com",
-			AuthorizationServer: authServer.URL,
-			Scopes:              []string{"read", "write"},
-		})
-	}))
-	defer metadataServer.Close()
-
 	// Mock MCP server (returns 401 WITH WWW-Authenticate) - TLS
 	mcpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseURL := "https://" + r.Host
 		if r.URL.Path == "/mcp" {
 			// Return 401 WITH WWW-Authenticate header (standard MCP behavior)
-			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer realm=\"test\", resource_metadata=\"%s\"", metadataServer.URL))
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer realm=\"test\", resource_metadata=\"%s/oauth-metadata\"", baseURL))
 			w.WriteHeader(http.StatusUnauthorized)
 			return
+		}
+		if r.URL.Path == "/oauth-metadata" {
+			_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+				Resource:            baseURL + "/mcp",
+				AuthorizationServer: authServer.URL,
+				Scopes:              []string{"read", "write"},
+			})
 		}
 	}))
 	defer mcpServer.Close()
@@ -172,6 +171,9 @@ func TestDiscoveryHappyPath_WithWWWAuthenticate(t *testing.T) {
 	if len(discovery.Scopes) != 2 {
 		t.Errorf("Expected 2 scopes from metadata, got %d", len(discovery.Scopes))
 	}
+	if discovery.ResourceURL != mcpServer.URL+"/mcp" {
+		t.Errorf("Expected ResourceURL=%s, got %s", mcpServer.URL+"/mcp", discovery.ResourceURL)
+	}
 }
 
 // TestDiscoveryError_AuthServerFails verifies error handling
@@ -186,11 +188,11 @@ func TestDiscoveryError_AuthServerFails(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		if r.URL.Path == "/.well-known/oauth-protected-resource" {
+		if r.URL.Path == "/.well-known/oauth-protected-resource/mcp" {
 			// Return resource metadata pointing to non-existent auth server
 			baseURL := "https://" + r.Host
 			_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
-				Resource:            baseURL,
+				Resource:            baseURL + "/mcp",
 				AuthorizationServer: "https://localhost:99999", // Invalid/unreachable
 			})
 			return
@@ -210,6 +212,189 @@ func TestDiscoveryError_AuthServerFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "fetching authorization server metadata") {
 		t.Errorf("Expected auth server error, got: %v", err)
+	}
+}
+
+func TestDiscoveryRejectsCrossOriginResourceMetadataBeforeFetch(t *testing.T) {
+	cleanup := setupTestHTTPClient(t)
+	defer cleanup()
+
+	var metadataCalled atomic.Bool
+	metadataServer := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		metadataCalled.Store(true)
+	}))
+	defer metadataServer.Close()
+
+	mcpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/mcp" {
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer resource_metadata=\"%s/metadata\"", metadataServer.URL))
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer mcpServer.Close()
+
+	_, err := DiscoverOAuthRequirements(context.Background(), mcpServer.URL+"/mcp")
+	if err == nil || !strings.Contains(err.Error(), "must use the same origin") {
+		t.Fatalf("expected same-origin validation error, got %v", err)
+	}
+	if metadataCalled.Load() {
+		t.Fatal("cross-origin resource metadata endpoint must not be fetched")
+	}
+}
+
+func TestDiscoveryRejectsCrossOriginResourceMetadataRedirect(t *testing.T) {
+	cleanup := setupTestHTTPClient(t)
+	defer cleanup()
+
+	var redirectTargetCalled atomic.Bool
+	redirectTarget := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirectTargetCalled.Store(true)
+	}))
+	defer redirectTarget.Close()
+
+	mcpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseURL := "https://" + r.Host
+		switch r.URL.Path {
+		case "/mcp":
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer resource_metadata=\"%s/metadata\"", baseURL))
+			w.WriteHeader(http.StatusUnauthorized)
+		case "/metadata":
+			http.Redirect(w, r, redirectTarget.URL+"/captured", http.StatusFound)
+		}
+	}))
+	defer mcpServer.Close()
+
+	_, err := DiscoverOAuthRequirements(context.Background(), mcpServer.URL+"/mcp")
+	if err == nil || !strings.Contains(err.Error(), "must use the same origin") {
+		t.Fatalf("expected redirected metadata origin error, got %v", err)
+	}
+	if redirectTargetCalled.Load() {
+		t.Fatal("cross-origin resource metadata redirect target must not be fetched")
+	}
+}
+
+func TestDiscoveryRejectsMismatchedProtectedResource(t *testing.T) {
+	cleanup := setupTestHTTPClient(t)
+	defer cleanup()
+
+	mcpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseURL := "https://" + r.Host
+		switch r.URL.Path {
+		case "/mcp":
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer resource_metadata=\"%s/metadata\"", baseURL))
+			w.WriteHeader(http.StatusUnauthorized)
+		case "/metadata":
+			_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+				Resource:            baseURL + "/other",
+				AuthorizationServer: "https://auth.example.com",
+			})
+		}
+	}))
+	defer mcpServer.Close()
+
+	_, err := DiscoverOAuthRequirements(context.Background(), mcpServer.URL+"/mcp")
+	if err == nil || !strings.Contains(err.Error(), "does not match requested resource") {
+		t.Fatalf("expected protected resource mismatch error, got %v", err)
+	}
+}
+
+func TestFetchAuthorizationServerMetadataRejectsIssuerMismatch(t *testing.T) {
+	cleanup := setupTestHTTPClient(t)
+	defer cleanup()
+
+	authServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseURL := "https://" + r.Host
+		_ = json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+			Issuer:                baseURL + "/",
+			AuthorizationEndpoint: baseURL + "/authorize",
+			TokenEndpoint:         baseURL + "/token",
+		})
+	}))
+	defer authServer.Close()
+
+	_, err := fetchAuthorizationServerMetadata(context.Background(), httpClientFunc(), authServer.URL)
+	if err == nil || !strings.Contains(err.Error(), "does not match requested issuer") {
+		t.Fatalf("expected exact issuer mismatch error, got %v", err)
+	}
+}
+
+func TestBuildRFC9728WellKnownURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "origin resource",
+			resource: "https://example.com",
+			expected: "https://example.com/.well-known/oauth-protected-resource",
+		},
+		{
+			name:     "path and query",
+			resource: "https://EXAMPLE.COM/mcp%20server?tenant=one",
+			expected: "https://example.com/.well-known/oauth-protected-resource/mcp%20server?tenant=one",
+		},
+		{
+			name:     "root path",
+			resource: "https://example.com/",
+			expected: "https://example.com/.well-known/oauth-protected-resource",
+		},
+		{
+			name:     "fragment rejected",
+			resource: "https://example.com/mcp#fragment",
+			wantErr:  true,
+		},
+		{
+			name:     "relative URL rejected",
+			resource: "/mcp",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := buildRFC9728WellKnownURL(tt.resource)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.resource)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != tt.expected {
+				t.Errorf("buildRFC9728WellKnownURL(%q) = %q, want %q", tt.resource, actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateSameOrigin(t *testing.T) {
+	tests := []struct {
+		name        string
+		serverURL   string
+		metadataURL string
+		wantErr     bool
+	}{
+		{name: "same origin", serverURL: "https://EXAMPLE.com/mcp", metadataURL: "https://example.COM/metadata"},
+		{name: "equivalent default port", serverURL: "https://example.com/mcp", metadataURL: "https://example.com:443/metadata"},
+		{name: "sibling host", serverURL: "https://mcp.example.com/mcp", metadataURL: "https://metadata.example.com/metadata", wantErr: true},
+		{name: "different scheme", serverURL: "https://example.com/mcp", metadataURL: "http://example.com/metadata", wantErr: true},
+		{name: "different port", serverURL: "https://example.com/mcp", metadataURL: "https://example.com:8443/metadata", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSameOrigin(tt.serverURL, tt.metadataURL)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected origin mismatch")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected origin error: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Context

OAuth discovery currently trusts the protected-resource metadata location and identity too broadly. A malicious MCP endpoint can advertise metadata on another origin, redirect a same-origin metadata URL to another origin, return metadata for a different protected resource, or provide authorization-server metadata whose issuer does not match the issuer requested by the client.

This moves the discovery hardening out of the MCP Gateway vendor tree and into the shared helper module so every consumer gets the same validation behavior.

## What changed

- Require an advertised `resource_metadata` URL to use the MCP server's scheme, host, and effective port.
- Enforce the same-origin constraint on every protected-resource metadata redirect hop.
- Require the protected-resource metadata `resource` value to exactly match the full MCP server URL being probed, including path and query.
- Build fallback protected-resource metadata URLs using RFC 9728's path-aware well-known form.
- Preserve the full MCP server URL as `ResourceURL` and `ResourceServer` instead of reducing it to the origin.
- Require exact equality between the requested authorization-server issuer and the returned RFC 8414 `issuer` value.
- Preserve the existing RFC 8414 issuer-path handling added in #5.

Exact equality is intentional: trailing-slash, path, and query differences identify a different resource or issuer and are rejected.

## Validation

- `go test ./...`
- `make test`
- `make lint` (Linux, Darwin, and Windows; 0 issues)
- `goimports@v0.36.0` and `gofumpt@v0.8.0` on changed files
- `git diff --check`

`make format` currently fails before reading the source because its Go 1.24.5 image installs `golang.org/x/tools/cmd/goimports@latest`, which now requires Go 1.25. The changed files were formatted with compatible pinned versions instead.

## Manual testing

1. Configure an MCP endpoint to advertise a sibling-host `resource_metadata` URL. Confirm discovery fails before that host receives a request.
2. Advertise a same-origin metadata URL that redirects to another host or port. Confirm discovery fails at the redirect and the target receives no request.
3. Return protected-resource metadata whose `resource` differs from the probed MCP URL by path, query, or trailing slash. Confirm discovery fails before authorization-server discovery.
4. Return metadata with the exact MCP resource URL. Confirm discovery proceeds and exposes the full resource URL.
5. Return authorization-server metadata whose `issuer` differs from the requested issuer, including only by a trailing slash. Confirm discovery rejects it; return the exact issuer and confirm discovery succeeds.
6. Probe an MCP resource with a path and query and confirm fallback lookup uses `/.well-known/oauth-protected-resource/<resource-path>?<resource-query>`.
