### PR TITLE
Guard authorization server metadata fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ This library provides the core OAuth/DCR functions for MCP Gateway:
 - **Dynamic Client Registration**: Register OAuth clients automatically (RFC 7591)
 - **WWW-Authenticate Parsing**: Parse OAuth challenge headers
 
+## Local development
+
+OAuth discovery allows only public HTTPS authorization servers by default. It
+rejects localhost, private, link-local, and reserved destinations before
+dialing, including redirect targets.
+
+For local development with an HTTP or private-network OAuth provider, set
+`DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS=1`. This disables the authorization
+server network guard and HTTPS requirement, so it must not be enabled with
+untrusted MCP servers.
+
 ## Configuring redirect URI validation
 
 By default DCR only accepts redirect URI hosts for localhost, `mcp.docker.com`, and `mcp-stage.docker.com`.

--- a/discovery.go
+++ b/discovery.go
@@ -280,8 +280,10 @@ func buildRFC8414WellKnownURL(issuerURL string) (string, error) {
 		return "", fmt.Errorf("invalid issuer URL: %w", err)
 	}
 
-	// RFC 8414 Section 2: issuer must use https scheme
-	if parsed.Scheme != "https" {
+	// RFC 8414 Section 2 requires HTTPS. Local development can explicitly
+	// opt into insecure remote URLs to exercise HTTP-only OAuth providers.
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "https" && (scheme != "http" || !allowInsecureRemoteURLs()) {
 		return "", fmt.Errorf("issuer URL must use https scheme")
 	}
 
@@ -305,8 +307,8 @@ func buildRFC8414WellKnownURL(issuerURL string) (string, error) {
 		path = ""
 	}
 
-	return fmt.Sprintf("https://%s/.well-known/oauth-authorization-server%s",
-		host, path), nil
+	return fmt.Sprintf("%s://%s/.well-known/oauth-authorization-server%s",
+		scheme, host, path), nil
 }
 
 // fetchAuthorizationServerMetadata fetches metadata from /.well-known/oauth-authorization-server

--- a/discovery.go
+++ b/discovery.go
@@ -109,7 +109,9 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 	authServerURL := defaultAuthServerURL
 	resourceMetadataClient := sameOriginHTTPClient(client, serverURL)
 
-	// STEP 4: Try to get resource metadata (OPTIONAL - don't fail if missing)
+	// STEP 4: Resolve protected resource metadata. Discovery may continue when
+	// the fallback well-known endpoint is absent, but explicitly advertised
+	// resource_metadata is authoritative and must be fetched successfully.
 	// RFC 9728 Section 5.1: resource_metadata parameter in WWW-Authenticate
 	resourceMetadataURL := ""
 	if challenges != nil {
@@ -129,12 +131,10 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 		if err := validateProtectedResource(serverURL, resourceMetadata.Resource); err != nil {
 			return nil, err
 		}
-		if resourceMetadataError == nil && resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
+		if resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
 			// Use authorization server from resource metadata if available
 			authServerURL = resourceMetadata.AuthorizationServer
 			logger.Infof("resource metadata retrieved, auth server: %s", authServerURL)
-		} else if resourceMetadataError != nil {
-			logger.Warnf("failed to fetch resource metadata: %v", resourceMetadataError)
 		}
 	} else {
 		// No resource_metadata in WWW-Authenticate - try well-known endpoint
@@ -158,7 +158,11 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 	// STEP 5: Fetch Authorization Server Metadata (REQUIRED)
 	// MCP Spec Section 3.1: "Authorization servers MUST provide OAuth 2.0 Authorization Server Metadata (RFC8414)"
 	logger.Infof("fetching authorization server metadata from: %s", authServerURL)
-	authServerMetadata, err := fetchAuthorizationServerMetadata(ctx, client, authServerURL)
+	authServerClient, err := authorizationServerHTTPClientFunc(client)
+	if err != nil {
+		return nil, fmt.Errorf("securing authorization server metadata client: %w", err)
+	}
+	authServerMetadata, err := fetchAuthorizationServerMetadata(ctx, authServerClient, authServerURL)
 	if err != nil {
 		logger.Warnf("failed to fetch authorization server metadata: %v", err)
 		return nil, fmt.Errorf("fetching authorization server metadata from %s: %w", authServerURL, err)

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -5,8 +5,10 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -15,6 +17,7 @@ import (
 // setupTestHTTPClient configures httpClientFunc to accept test TLS certificates
 func setupTestHTTPClient(_ *testing.T) func() {
 	original := httpClientFunc
+	originalAuthorizationServerClientFunc := authorizationServerHTTPClientFunc
 	httpClientFunc = func() *http.Client {
 		return &http.Client{
 			Transport: &http.Transport{
@@ -22,8 +25,12 @@ func setupTestHTTPClient(_ *testing.T) func() {
 			},
 		}
 	}
+	authorizationServerHTTPClientFunc = func(client *http.Client) (*http.Client, error) {
+		return client, nil
+	}
 	return func() {
 		httpClientFunc = original
+		authorizationServerHTTPClientFunc = originalAuthorizationServerClientFunc
 	}
 }
 
@@ -212,6 +219,128 @@ func TestDiscoveryError_AuthServerFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "fetching authorization server metadata") {
 		t.Errorf("Expected auth server error, got: %v", err)
+	}
+}
+
+func TestDiscoveryRejectsPrivateAuthorizationServerBeforeFetch(t *testing.T) {
+	original := httpClientFunc
+	defer func() { httpClientFunc = original }()
+
+	var privateDialed atomic.Bool
+	dialer := &net.Dialer{}
+	httpClientFunc = func() *http.Client {
+		return &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+					if strings.HasPrefix(address, "169.254.169.254:") {
+						privateDialed.Store(true)
+					}
+					return dialer.DialContext(ctx, network, address)
+				},
+			},
+		}
+	}
+
+	mcpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseURL := "https://" + r.Host
+		switch r.URL.Path {
+		case "/mcp":
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer resource_metadata=\"%s/metadata\"", baseURL))
+			w.WriteHeader(http.StatusUnauthorized)
+		case "/metadata":
+			_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+				Resource:            baseURL + "/mcp",
+				AuthorizationServer: "https://169.254.169.254/latest/meta-data",
+			})
+		}
+	}))
+	defer mcpServer.Close()
+
+	_, err := DiscoverOAuthRequirements(context.Background(), mcpServer.URL+"/mcp")
+	if err == nil || !strings.Contains(err.Error(), "blocked range 169.254.0.0/16") {
+		t.Fatalf("expected private authorization server rejection, got %v", err)
+	}
+	if privateDialed.Load() {
+		t.Fatal("private authorization server must be rejected before dialing")
+	}
+}
+
+type staticResolver map[string][]netip.Addr
+
+func (r staticResolver) LookupNetIP(_ context.Context, _, host string) ([]netip.Addr, error) {
+	return r[host], nil
+}
+
+func TestAuthorizationServerClientRejectsPrivateDNSResultBeforeDial(t *testing.T) {
+	var dialed atomic.Bool
+	baseClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(context.Context, string, string) (net.Conn, error) {
+				dialed.Store(true)
+				return nil, fmt.Errorf("unexpected dial")
+			},
+		},
+	}
+	client, err := newAuthorizationServerHTTPClientWithResolver(baseClient, staticResolver{
+		"auth.example.com": {netip.MustParseAddr("10.0.0.1")},
+	})
+	if err != nil {
+		t.Fatalf("creating guarded client: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://auth.example.com/.well-known/oauth-authorization-server", nil)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	_, err = client.Do(req)
+	if err == nil || !strings.Contains(err.Error(), "blocked range 10.0.0.0/8") {
+		t.Fatalf("expected private DNS result rejection, got %v", err)
+	}
+	if dialed.Load() {
+		t.Fatal("private DNS result must be rejected before dialing")
+	}
+}
+
+func TestAuthorizationServerClientRejectsRedirectToPrivateAddress(t *testing.T) {
+	var dialCount atomic.Int32
+	var dialedAddress string
+	redirector := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://169.254.169.254/latest/meta-data", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	dialer := &net.Dialer{}
+	baseClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+				dialCount.Add(1)
+				dialedAddress = address
+				return dialer.DialContext(ctx, network, redirector.Listener.Addr().String())
+			},
+		},
+	}
+	client, err := newAuthorizationServerHTTPClientWithResolver(baseClient, staticResolver{
+		"auth.example.com": {netip.MustParseAddr("93.184.216.34")},
+	})
+	if err != nil {
+		t.Fatalf("creating guarded client: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://auth.example.com/.well-known/oauth-authorization-server", nil)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	_, err = client.Do(req)
+	if err == nil || !strings.Contains(err.Error(), "blocked range 169.254.0.0/16") {
+		t.Fatalf("expected private redirect rejection, got %v", err)
+	}
+	if got := dialCount.Load(); got != 1 {
+		t.Fatalf("expected only the public redirector to be dialed, got %d dials", got)
+	}
+	if dialedAddress != "93.184.216.34:443" {
+		t.Fatalf("expected the validated public IP to be pinned, got %q", dialedAddress)
 	}
 }
 

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -223,6 +223,8 @@ func TestDiscoveryError_AuthServerFails(t *testing.T) {
 }
 
 func TestDiscoveryRejectsPrivateAuthorizationServerBeforeFetch(t *testing.T) {
+	t.Setenv(allowInsecureRemoteURLEnv, "")
+
 	original := httpClientFunc
 	defer func() { httpClientFunc = original }()
 
@@ -266,6 +268,42 @@ func TestDiscoveryRejectsPrivateAuthorizationServerBeforeFetch(t *testing.T) {
 	}
 }
 
+func TestDiscoveryAllowsLocalHTTPAuthorizationServerWithOptIn(t *testing.T) {
+	t.Setenv(allowInsecureRemoteURLEnv, "1")
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mcp":
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer resource_metadata=\"%s/metadata\"", server.URL))
+			w.WriteHeader(http.StatusUnauthorized)
+		case "/metadata":
+			_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+				Resource:            server.URL + "/mcp",
+				AuthorizationServer: server.URL,
+			})
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+				Issuer:                server.URL,
+				AuthorizationEndpoint: server.URL + "/authorize",
+				TokenEndpoint:         server.URL + "/token",
+			})
+		}
+	}))
+	defer server.Close()
+
+	discovery, err := DiscoverOAuthRequirements(context.Background(), server.URL+"/mcp")
+	if err != nil {
+		t.Fatalf("discovering local OAuth server: %v", err)
+	}
+	if discovery.AuthorizationServer != server.URL {
+		t.Fatalf("expected authorization server %q, got %q", server.URL, discovery.AuthorizationServer)
+	}
+	if discovery.TokenEndpoint != server.URL+"/token" {
+		t.Fatalf("expected token endpoint %q, got %q", server.URL+"/token", discovery.TokenEndpoint)
+	}
+}
+
 type staticResolver map[string][]netip.Addr
 
 func (r staticResolver) LookupNetIP(_ context.Context, _, host string) ([]netip.Addr, error) {
@@ -273,6 +311,8 @@ func (r staticResolver) LookupNetIP(_ context.Context, _, host string) ([]netip.
 }
 
 func TestAuthorizationServerClientRejectsPrivateDNSResultBeforeDial(t *testing.T) {
+	t.Setenv(allowInsecureRemoteURLEnv, "")
+
 	var dialed atomic.Bool
 	baseClient := &http.Client{
 		Transport: &http.Transport{
@@ -302,7 +342,39 @@ func TestAuthorizationServerClientRejectsPrivateDNSResultBeforeDial(t *testing.T
 	}
 }
 
+func TestAuthorizationServerClientRejectsLocalhostByDefault(t *testing.T) {
+	t.Setenv(allowInsecureRemoteURLEnv, "")
+
+	var dialed atomic.Bool
+	baseClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(context.Context, string, string) (net.Conn, error) {
+				dialed.Store(true)
+				return nil, fmt.Errorf("unexpected dial")
+			},
+		},
+	}
+	client, err := newAuthorizationServerHTTPClientWithResolver(baseClient, staticResolver{})
+	if err != nil {
+		t.Fatalf("creating guarded client: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://localhost/.well-known/oauth-authorization-server", nil)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	_, err = client.Do(req)
+	if err == nil || !strings.Contains(err.Error(), "host \"localhost\" is not allowed") {
+		t.Fatalf("expected localhost rejection, got %v", err)
+	}
+	if dialed.Load() {
+		t.Fatal("localhost must be rejected before dialing")
+	}
+}
+
 func TestAuthorizationServerClientRejectsRedirectToPrivateAddress(t *testing.T) {
+	t.Setenv(allowInsecureRemoteURLEnv, "")
+
 	var dialCount atomic.Int32
 	var dialedAddress string
 	redirector := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -529,6 +601,8 @@ func TestValidateSameOrigin(t *testing.T) {
 
 // TestBuildRFC8414WellKnownURL verifies RFC 8414 Section 3.1 URL construction
 func TestBuildRFC8414WellKnownURL(t *testing.T) {
+	t.Setenv(allowInsecureRemoteURLEnv, "")
+
 	tests := []struct {
 		name     string
 		issuer   string

--- a/ssrf.go
+++ b/ssrf.go
@@ -7,8 +7,11 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"os"
 	"strings"
 )
+
+const allowInsecureRemoteURLEnv = "DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS"
 
 type ipResolver interface {
 	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
@@ -27,6 +30,10 @@ func newAuthorizationServerHTTPClient(client *http.Client) (*http.Client, error)
 func newAuthorizationServerHTTPClientWithResolver(client *http.Client, resolver ipResolver) (*http.Client, error) {
 	if client == nil {
 		return nil, fmt.Errorf("HTTP client is nil")
+	}
+	if allowInsecureRemoteURLs() {
+		insecureClient := *client
+		return &insecureClient, nil
 	}
 	if resolver == nil {
 		return nil, fmt.Errorf("IP resolver is nil")
@@ -165,6 +172,11 @@ func isBlockedHostname(host string) bool {
 		}
 	}
 	return false
+}
+
+func allowInsecureRemoteURLs() bool {
+	value := os.Getenv(allowInsecureRemoteURLEnv)
+	return value == "1" || strings.EqualFold(value, "true")
 }
 
 var blockedPrefixes = []netip.Prefix{

--- a/ssrf.go
+++ b/ssrf.go
@@ -1,0 +1,215 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+)
+
+type ipResolver interface {
+	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
+}
+
+var authorizationServerHTTPClientFunc = newAuthorizationServerHTTPClient
+
+// newAuthorizationServerHTTPClient limits attacker-influenced authorization
+// server metadata requests to public HTTPS destinations. It resolves and pins
+// the address at dial time so DNS rebinding cannot redirect the connection to
+// a private service. The guarded transport is also used for every redirect.
+func newAuthorizationServerHTTPClient(client *http.Client) (*http.Client, error) {
+	return newAuthorizationServerHTTPClientWithResolver(client, net.DefaultResolver)
+}
+
+func newAuthorizationServerHTTPClientWithResolver(client *http.Client, resolver ipResolver) (*http.Client, error) {
+	if client == nil {
+		return nil, fmt.Errorf("HTTP client is nil")
+	}
+	if resolver == nil {
+		return nil, fmt.Errorf("IP resolver is nil")
+	}
+
+	base := client.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	transport, ok := base.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("HTTP transport %T cannot be guarded at dial time", base)
+	}
+
+	guardedTransport := transport.Clone()
+	if guardedTransport.DialTLS != nil || //nolint:staticcheck // A legacy TLS dialer would bypass the guarded DialContext.
+		guardedTransport.DialTLSContext != nil {
+		return nil, fmt.Errorf("HTTP transport with a custom TLS dialer cannot be guarded at dial time")
+	}
+	// A generic proxy cannot guarantee that the validated address is the one
+	// ultimately dialed. Authorization-server discovery therefore uses a direct
+	// connection whose resolved public address is pinned below.
+	guardedTransport.Proxy = nil
+
+	originalDialContext := guardedTransport.DialContext
+	if originalDialContext == nil {
+		originalDialContext = (&net.Dialer{}).DialContext
+	}
+	guardedTransport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, fmt.Errorf("invalid authorization server dial address %q: %w", address, err)
+		}
+		return dialPublicAddress(ctx, resolver, originalDialContext, network, host, port)
+	}
+
+	guardedClient := *client
+	guardedClient.Transport = &publicOnlyRoundTripper{base: guardedTransport}
+	return &guardedClient, nil
+}
+
+type publicOnlyRoundTripper struct {
+	base http.RoundTripper
+}
+
+func (t *publicOnlyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := validatePublicHTTPSURL(req.URL); err != nil {
+		return nil, err
+	}
+	return t.base.RoundTrip(req)
+}
+
+func validatePublicHTTPSURL(target *url.URL) error {
+	if target == nil || target.Scheme == "" || target.Host == "" {
+		return fmt.Errorf("authorization server URL must be absolute")
+	}
+	if !strings.EqualFold(target.Scheme, "https") {
+		return fmt.Errorf("authorization server URL must use https")
+	}
+	if target.User != nil {
+		return fmt.Errorf("authorization server URL must not include userinfo")
+	}
+
+	host := normalizeHostname(target.Hostname())
+	if host == "" || strings.ContainsAny(host, "\x00%") {
+		return fmt.Errorf("authorization server URL host is malformed")
+	}
+	if isBlockedHostname(host) {
+		return fmt.Errorf("authorization server URL host %q is not allowed", host)
+	}
+	if ip, err := netip.ParseAddr(host); err == nil {
+		if err := validatePublicAddr(ip); err != nil {
+			return fmt.Errorf("authorization server URL host %q is not allowed: %w", host, err)
+		}
+	}
+	return nil
+}
+
+func dialPublicAddress(
+	ctx context.Context,
+	resolver ipResolver,
+	dial func(context.Context, string, string) (net.Conn, error),
+	network, host, port string,
+) (net.Conn, error) {
+	if ip, err := netip.ParseAddr(host); err == nil {
+		if err := validatePublicAddr(ip); err != nil {
+			return nil, err
+		}
+		return dial(ctx, network, net.JoinHostPort(ip.String(), port))
+	}
+
+	ips, err := resolver.LookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return nil, fmt.Errorf("resolving authorization server host %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("authorization server host %q did not resolve to any IP addresses", host)
+	}
+	for _, ip := range ips {
+		if err := validatePublicAddr(ip); err != nil {
+			return nil, fmt.Errorf("authorization server host %q resolved to disallowed address %s: %w", host, ip, err)
+		}
+	}
+
+	var lastErr error
+	for _, ip := range ips {
+		conn, err := dial(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+func normalizeHostname(host string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+}
+
+func isBlockedHostname(host string) bool {
+	host = normalizeHostname(host)
+	switch host {
+	case "localhost", "metadata", "metadata.google.internal", "metadata.azure.internal":
+		return true
+	}
+	for _, suffix := range []string{
+		".localhost",
+		".local",
+		".localdomain",
+		".internal",
+		".cluster.local",
+		".svc",
+	} {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+var blockedPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("255.255.255.255/32"),
+	netip.MustParsePrefix("::/128"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+	netip.MustParsePrefix("ff00::/8"),
+	netip.MustParsePrefix("2001:db8::/32"),
+}
+
+func validatePublicAddr(ip netip.Addr) error {
+	if !ip.IsValid() {
+		return fmt.Errorf("invalid IP address")
+	}
+	if ip.Zone() != "" {
+		return fmt.Errorf("scoped IPv6 addresses are not allowed")
+	}
+
+	ip = ip.Unmap()
+	for _, prefix := range blockedPrefixes {
+		if prefix.Contains(ip) {
+			return fmt.Errorf("address is in blocked range %s", prefix)
+		}
+	}
+	if !ip.IsGlobalUnicast() || ip.IsLoopback() || ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsUnspecified() {
+		return fmt.Errorf("address is not public")
+	}
+	return nil
+}


### PR DESCRIPTION
## Context

Follow-up to #9. Protected-resource metadata can legitimately identify a cross-origin authorization server, but that value is controlled by the MCP endpoint. The issuer comparison added in #9 validates the response only after the metadata request has already been sent. Without a dial-time guard, a malicious endpoint can point discovery at a private service or metadata address, including through a redirect.

## What changed

- Build a dedicated guarded client before fetching RFC 8414 authorization-server metadata.
- Require every authorization-server metadata request and redirect hop to use a public HTTPS destination without userinfo.
- Resolve hostnames at dial time, reject private, loopback, link-local, multicast, reserved, benchmark, and documentation ranges, and pin the connection to the validated IP to prevent DNS rebinding.
- Disable generic proxy routing for this security-sensitive fetch because a generic proxy cannot prove that the validated address is the destination ultimately dialed.
- Fail closed for custom transports whose TLS dialer would bypass the guarded dial path.
- Honor `DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS=1` as an explicit local-development escape hatch. It permits HTTP and local/private authorization servers and bypasses the authorization-server network guard.
- Document the opt-in and its security tradeoff.
- Clarify that an explicitly advertised `resource_metadata` endpoint is authoritative and fetch failures are fatal, while absence of the fallback well-known endpoint remains tolerated for compatibility.

## Security behavior

Cross-origin authorization servers remain supported when they resolve exclusively to public addresses. Direct private IPs, public names resolving to any blocked address, localhost, and redirects to blocked destinations fail before a connection is made.

Local or private OAuth remains available only when `DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS` is set to `1` or `true`. This opt-in disables both the HTTPS requirement and the authorization-server network guard, so it must not be enabled with untrusted MCP servers.

## Automated validation

- `go test -race ./...`
- `make test`
- `make lint` on Linux, Darwin, and Windows
- `goimports@v0.36.0`
- `gofumpt@v0.8.0`
- `git diff --check`

`make format` currently fails before reading source because the Go 1.24.5 formatter image installs `goimports@latest`, which now requires Go 1.25. No workflow or Dockerfile changes are included here.

## Manual testing

1. With the insecure opt-in unset, configure an MCP test endpoint to advertise same-origin protected-resource metadata whose `authorization_server` is `https://169.254.169.254/latest/meta-data`.
2. Run OAuth discovery and confirm it fails with a blocked-range error before the metadata address receives a connection.
3. Repeat with a hostname that resolves to `10.0.0.1`; confirm the hostname is rejected before dialing.
4. Configure a public HTTPS authorization-server metadata endpoint that redirects to a private or link-local address; confirm the public endpoint receives one request and the redirect target receives none.
5. Configure a cross-origin public HTTPS authorization server with exact issuer metadata; confirm discovery still succeeds.
6. Configure a localhost MCP endpoint with a localhost HTTP OAuth issuer. Confirm discovery fails by default, then set `DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS=1` and confirm discovery succeeds through authorization-server metadata retrieval.